### PR TITLE
Fix a root path

### DIFF
--- a/analysis/scripts/_helpers_usa.py
+++ b/analysis/scripts/_helpers_usa.py
@@ -126,7 +126,7 @@ def mock_snakemake(
     """
     script_dir = pathlib.Path(__file__).parent.resolve()
     if root_dir is None:
-        root_dir = script_dir.parent
+        root_dir = script_dir.parent.parent
     else:
         root_dir = pathlib.Path(root_dir).resolve()
 


### PR DESCRIPTION
A little bug-fix needed to run local debug.

I suspect the need for the fix is linked with the fact that `scripts` folder has been moved into `analysis` folder while `mock_snakemake` hasn't been adjusted accordingly.